### PR TITLE
Bugfix 0.4.4

### DIFF
--- a/sapp/forms.py
+++ b/sapp/forms.py
@@ -255,7 +255,7 @@ class SlurmConfigForm(FormMultiPageAction):
         partition_widget.entry_widget.when_value_edited = when_value_edited
 
         self.auto_add(npyscreen.TitleSlider, w_id="num_gpus", value=self.slurm_config.num_gpus, lowest=0, out_of=16, name = "# gpus", comments="Number of GPUs to request.")
-        self.auto_add(npyscreen.TitleSlider, w_id="cpus_per_task", value=self.slurm_config.cpus_per_task, lowest=1, out_of=32, name = "# cpus per task", comments="Request that ncpus be allocated per process. This may be useful if the job is multithreaded.")
+        self.auto_add(npyscreen.TitleSlider, w_id="cpus_per_task", value=self.slurm_config.cpus_per_task, lowest=1, out_of=128, name = "# cpus per task", comments="Request that ncpus be allocated per process. This may be useful if the job is multithreaded.")
         self.auto_add(npyscreen.TitleText, w_id="mem", value=self.slurm_config.mem, name = "Memory", comments="(Optional) Specify the real memory required per node. E.g. 40G.")
         self.auto_add(npyscreen.TitleText, w_id="other", value=self.slurm_config.other, name = "Other", comments="(Optional) Other command line arguments, such as '--exclude ai_gpu02,ai_gpu04'.")
     

--- a/sapp/forms.py
+++ b/sapp/forms.py
@@ -533,6 +533,9 @@ class SubmitForm(FormMultiPageAction):
         self.submit_config.jobname = self.get_widget("jobname").value
         self.submit_config.output = self.get_widget("output").value
         self.submit_config.error = self.get_widget("error").value
+        mail_type = self.get_widget("mail_type").value
+        self.submit_config.mail_type = [self.get_widget("mail_type").values[i] for i in mail_type] if mail_type else None
+        self.submit_config.mail_user = self.get_widget("mail_user").value
 
         # proceed to exit
         self.parentApp.setNextForm(None)
@@ -560,6 +563,9 @@ class SubmitForm(FormMultiPageAction):
         self.auto_add(npyscreen.TitleText, w_id="time", value="0-01:00:00", name = "Time", comments="Limit on the total run time of the job allocation. E.g. 0-01:00:00")
         output = self.auto_add(npyscreen.TitleFilenameCombo, w_id="output", name = "Output", comments="(Optional) The output filename. use %j for job id, %x for job name and %i for timestamp. You may want to leave it blank for srun.")
         error = self.auto_add(npyscreen.TitleFilenameCombo, w_id="error", name = "Error", comments="(Optional) The stderr filename. use %j for job id, %x for job name and %i for timestamp. You may want to leave it blank for srun.")
+        height = min(max(2, self.lines-self.text.height-6), 4)
+        self.auto_add(TitleMultiSelect, w_id="mail_type", name = "Mail Type", scroll_exit=True, select_exit=True, max_height=height, values = ["NONE", "BEGIN", "END", "FAIL", "REQUEUE", "ALL", "INVALID_DEPEND", "STAGE_OUT", "TIME_LIMIT", "TIME_LIMIT_90", "TIME_LIMIT_80", "TIME_LIMIT_50", "ARRAY_TASKS"], comments="(Optional) Mail type, the time you want to receive email. See sbatch manual for details.")
+        self.auto_add(npyscreen.TitleText, w_id="mail_user", name = "Mail User", comments="(Optional) Mail address to send the mail to. Leave it blank to send to your email address.")
 
         def when_value_edited():
             database: Database = self.parentApp.database

--- a/sapp/gpustat.py
+++ b/sapp/gpustat.py
@@ -69,7 +69,7 @@ def get_card_list():
     resources = {}
     for partition in partitions:
         part_status = defaultdict(int)
-        response = run_cammand(['sinfo', '-O', 'StateCompact:.10,Gres:.30,GresUsed:.50', '-p', partition, '--noheader'])
+        response = run_cammand(['sinfo', '-N', '-O', 'StateCompact:.10,Gres:.30,GresUsed:.50', '-p', partition, '--noheader'])
         for line in response.split('\n'):
             parse = parse_gres_line(line)
             if parse is not None:

--- a/sapp/gpustat.py
+++ b/sapp/gpustat.py
@@ -51,8 +51,8 @@ def get_card_list():
     e.g.
     {
         "debug": {
-            "NVIDIAA40": 1,
-            "NVIDIATITANRTX": 0
+            "NVIDIAA40": [1, 0, 0],
+            "NVIDIATITANRTX": [0, 0]
         }
     }
     """
@@ -68,13 +68,13 @@ def get_card_list():
     ## Step 2: get the gpu status for each partition
     resources = {}
     for partition in partitions:
-        part_status = defaultdict(int)
+        part_status = defaultdict(list)
         response = run_cammand(['sinfo', '-N', '-O', 'StateCompact:.10,Gres:.30,GresUsed:.50', '-p', partition, '--noheader'])
         for line in response.split('\n'):
             parse = parse_gres_line(line)
             if parse is not None:
                 gpu, avail = parse
-                part_status[gpu] += avail
+                part_status[gpu].append(avail)
         resources[partition] = part_status
     
     return resources

--- a/sapp/slurm_config.py
+++ b/sapp/slurm_config.py
@@ -520,7 +520,7 @@ class Clash:
             self.exec_folder.mkdir(parents=True, exist_ok=True)
 
             # Since clash has been removed from github, we use a hidden repo.
-            url = 'https://github.com/Loyalsoldier/clash-rules/raw/hidden/software/clash/clash-linux-amd64-v1.18.0.gz'
+            url = 'https://raw.githubusercontent.com/Loyalsoldier/clash-rules/hidden/software/clash/clash-linux-amd64-v1.18.0.gz'
 
             r = requests.get(url, stream = True)
             total = int(r.headers.get('Content-Length', 0)) // 1024

--- a/sapp/slurm_config.py
+++ b/sapp/slurm_config.py
@@ -123,6 +123,21 @@ class SubmitConfig:
             "help": "(Optional) The stderr filename. use %j for job id and %x for job name. You may want to leave it blank for srun."
         }
     )
+    mail_type: Optional[List[str]] = field(
+        default=None,
+        metadata={
+            "help": "(Optional) Specify the type of mail notification requested.",
+            "options": [
+                "NONE", "BEGIN", "END", "FAIL", "REQUEUE", "ALL", "INVALID_DEPEND", "STAGE_OUT", "TIME_LIMIT", "TIME_LIMIT_90", "TIME_LIMIT_80", "TIME_LIMIT_50", "ARRAY_TASKS"
+            ]
+        }
+    )
+    mail_user: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "(Optional) Specify the email address to send notification to."
+        }
+    )
     task: int = field(
         default=None,
         metadata={
@@ -415,6 +430,8 @@ class utils:
                 if config.output: args += ["-o", utils.resolve_identifier(config.output, identifier)]
                 if config.error: args += ["-e", utils.resolve_identifier(config.error, identifier)]
                 if config.jobname: args += ["-J", config.jobname]
+                if config.mail_type: args += ["--mail-type", ",".join(config.mail_type)]
+                if config.mail_user: args += ["--mail-user", config.mail_user]
 
         elif tp == 'sbatch':
             args += ["#!/usr/bin/bash"]
@@ -435,6 +452,8 @@ class utils:
                 if config.output: args += [f"#SBATCH -o {utils.resolve_identifier(config.output, identifier)}"]
                 if config.error: args += [f"#SBATCH -e {utils.resolve_identifier(config.error, identifier)}"]
                 if config.jobname: args += [f"#SBATCH -J {config.jobname}"]
+                if config.mail_type: args += [f"#SBATCH --mail-type {','.join(config.mail_type)}"]
+                if config.mail_user: args += [f"#SBATCH --mail-user {config.mail_user}"]
         
         return args
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
  
 setup(
     name='sapp',
-    version='0.4.3',
+    version='0.4.3.dev',
     description='Command helper for slurm system. Act as if you are on compute node.',
     url="https://github.com/why-in-Shanghaitech/sapp",
     author='Haoyi Wu',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
  
 setup(
     name='sapp',
-    version='0.4.3.dev',
+    version='0.4.3.dev1',
     description='Command helper for slurm system. Act as if you are on compute node.',
     url="https://github.com/why-in-Shanghaitech/sapp",
     author='Haoyi Wu',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
  
 setup(
     name='sapp',
-    version='0.4.3.dev1',
+    version='0.4.4',
     description='Command helper for slurm system. Act as if you are on compute node.',
     url="https://github.com/why-in-Shanghaitech/sapp",
     author='Haoyi Wu',


### PR DESCRIPTION
This pull request fixes several bugs and adds some new features.

- [x] bug: sinfo -N
    - This bug leads to an underestimate of available cards. The output of sinfo may have multiple nodes in a single line. Add -N to enforce one node per line.
- [x] bug: start from an existing config will lead to wrong gpu type
    - This bug is from the npyscreen UI. When updating the partition name, the gpu type will be rewrite to the default (any type).
- [x] bug: cpu count
    - The previous max CPU count is too small. Now users could set at most 128 CPU cores per task.
- [x] feat: support avail
    - The previous implementation does not consider multi-gpu settings. Now the 'available' hints will consider the number of required gpus. That is, showing 'Available: x' means that the resource will support submitting x tasks to idle or mix nodes.
- [x] feat: support email
    - Add email settings to config.
- [x] feat: main page avail
    - Show available numbers for last time execution
- [x] feat: default value for walltime and email
    - Global setting for default values of walltime and email

To install sapp with this bug fix, please use

    pip install git+https://github.com/why-in-Shanghaitech/sapp.git@bugfix-0.4